### PR TITLE
workflow concurrency

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,6 +2,10 @@
 name: "Checks"
 on: pull_request
 
+concurrency:
+  group: checks-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 permissions:
   contents: read
 
+concurrency: release
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
release should release one at a time, so everything queues into the same queue. checks should just run the latest jobs, so it's ok to cancel previous jobs.